### PR TITLE
Enable vertical_whitespace + disable opening_brace

### DIFF
--- a/Configuration/.swiftlint.yml
+++ b/Configuration/.swiftlint.yml
@@ -7,4 +7,4 @@ variable_name:
     warning: 2
 line_length: 80
 disabled_rules:
-  - vertical_whitespace
+  - opening_brace


### PR DESCRIPTION
I would be nice to be able change tabs to spaces automatically. This is possible using `swiftlint autocorrect --format` but that messes up the formatting in many other places. TODO: Is it possible to adjust the formatting to our needs?