### PR TITLE
updated deprecated use of rule

### DIFF
--- a/Configuration/.swiftlint.yml
+++ b/Configuration/.swiftlint.yml
@@ -2,7 +2,7 @@ included:
   - Sources
 function_body_length:
   warning: 60
-variable_name:
+identifier_name:
   min_length:
     warning: 2
 line_length: 80


### PR DESCRIPTION
swiftlint warning: 'variable_name' rule has been renamed to 'identifier_name' and will be completely removed in a future release